### PR TITLE
Некорректная проверка Tag::BEHAVIOUR для тегов table/tr/ul

### DIFF
--- a/src/Tag/Tag.php
+++ b/src/Tag/Tag.php
@@ -141,7 +141,7 @@ abstract class Tag extends Xbbcode
      */
     protected function getBody()
     {
-        if (in_array(self::BEHAVIOUR, array('table', 'tr', 'ul'))) {
+        if (in_array(static::BEHAVIOUR, array('table', 'tr', 'ul'))) {
             $this->cleanTreeText();
         }
 

--- a/tests/Tag/LiTest.php
+++ b/tests/Tag/LiTest.php
@@ -5,10 +5,20 @@ use Xbbcode\Xbbcode;
 
 class LiTest extends \PHPUnit_Framework_TestCase
 {
-    public function testTag()
+    public function testTagWithUl()
     {
         $text = 'test [ul][li]xBBCode[/li][/ul].';
         $result = 'test <ul class="bb"><li class="bb">xBBCode</li></ul>.';
+
+        $xbbcode = new Xbbcode();
+        $xbbcode->parse($text);
+        $this->assertEquals($result, $xbbcode->getHtml());
+    }
+
+    public function testTagWithOl()
+    {
+        $text = 'test [ol][li]xBBCode[/li][/ol].';
+        $result = 'test <ol class="bb"><li class="bb">xBBCode</li></ol>.';
 
         $xbbcode = new Xbbcode();
         $xbbcode->parse($text);

--- a/tests/Tag/OlTest.php
+++ b/tests/Tag/OlTest.php
@@ -5,10 +5,10 @@ use Xbbcode\Xbbcode;
 
 class OlTest extends \PHPUnit_Framework_TestCase
 {
-    public function testTag()
+    public function testTagWithoutLi()
     {
         $text = 'test [ol]xBBCode[/ol].';
-        $result = 'test <ol class="bb">xBBCode</ol>.';
+        $result = 'test <ol class="bb"></ol>.';
 
         $xbbcode = new Xbbcode();
         $xbbcode->parse($text);

--- a/tests/Tag/TableTest.php
+++ b/tests/Tag/TableTest.php
@@ -5,10 +5,60 @@ use Xbbcode\Xbbcode;
 
 class TableTest extends \PHPUnit_Framework_TestCase
 {
-    public function testTag()
+    public function testTagWithoutTableCells()
     {
         $text = 'test [table]xBBCode[/table].';
-        $result = 'test <table class="bb">xBBCode</table>.';
+        $result = 'test <table class="bb"></table>.';
+
+        $xbbcode = new Xbbcode();
+        $xbbcode->parse($text);
+        $this->assertEquals($result, $xbbcode->getHtml());
+    }
+
+    public function testTag()
+    {
+        $text = 'test [table][tr][td]xBBCode[/td][/tr][/table].';
+        $result = 'test <table class="bb"><tr class="bb"><td class="bb">xBBCode</td></tr></table>.';
+
+        $xbbcode = new Xbbcode();
+        $xbbcode->parse($text);
+        $this->assertEquals($result, $xbbcode->getHtml());
+    }
+
+    public function testTagWithNewLines()
+    {
+        $text = <<<'BB'
+test [table]
+[tr]
+[td]
+xBBCode
+[/td]
+[/tr]
+[/table].
+BB;
+        $result = <<<'HTML'
+test <table class="bb"><tr class="bb"><td class="bb"><br />
+xBBCode<br />
+</td></tr></table>.
+HTML;
+
+        $xbbcode = new Xbbcode();
+        $xbbcode->parse($text);
+        $this->assertEquals($result, $xbbcode->getHtml());
+    }
+
+    public function testTagWithNewLinesAndSpaces()
+    {
+        $text = <<<'BB'
+test [table]
+  [tr]
+    [td]xBBCode[/td]
+  [/tr]
+[/table].
+BB;
+        $result = <<<'HTML'
+test <table class="bb"><tr class="bb"><td class="bb">xBBCode</td></tr></table>.
+HTML;
 
         $xbbcode = new Xbbcode();
         $xbbcode->parse($text);

--- a/tests/Tag/TrTest.php
+++ b/tests/Tag/TrTest.php
@@ -5,10 +5,10 @@ use Xbbcode\Xbbcode;
 
 class TrTest extends \PHPUnit_Framework_TestCase
 {
-    public function testTag()
+    public function testTagWithoutTdCell()
     {
         $text = 'test [table][tr]xBBCode[/tr][/table].';
-        $result = 'test <table class="bb"><tr class="bb">xBBCode</tr></table>.';
+        $result = 'test <table class="bb"><tr class="bb"></tr></table>.';
 
         $xbbcode = new Xbbcode();
         $xbbcode->parse($text);

--- a/tests/Tag/UlTest.php
+++ b/tests/Tag/UlTest.php
@@ -5,10 +5,10 @@ use Xbbcode\Xbbcode;
 
 class UlTest extends \PHPUnit_Framework_TestCase
 {
-    public function testTag()
+    public function testTagWithoutLi()
     {
         $text = 'test [ul]xBBCode[/ul].';
-        $result = 'test <ul class="bb">xBBCode</ul>.';
+        $result = 'test <ul class="bb"></ul>.';
 
         $xbbcode = new Xbbcode();
         $xbbcode->parse($text);


### PR DESCRIPTION
Заметил такой интересный баг: если при рендеринге тегов таблицы использовать пробелы/переносы строк между тегами table <=> tr <=> td, то эти пробелы не очищаются и превращаются в `<br />` и `&nbsp;`, хотя это работало корректно в оригинальной версии библиотеки.

Дело в том, что раньше у каждого тега было объявлено свойство `public $behaviour = 'div';` которое при рефакторинге было заменено на константу `const BEHAVIOUR = 'div'`.
Для корректной проверки этой константы нужно обращаться к `static::BEHAVIOUR `, а не к `self::BEHAVIOUR `.

Пример: https://3v4l.org/FXqZr