### PR TITLE
Tag::isValidTarget() расширена проверка согласно спецификации

### DIFF
--- a/src/Tag/Tag.php
+++ b/src/Tag/Tag.php
@@ -284,6 +284,7 @@ abstract class Tag extends Xbbcode
      */
     protected function isValidTarget($target)
     {
-        return \in_array(\strtolower($target), ['_blank', '_self', '_parent', '_top']);
+        return \in_array(\strtolower($target), ['_blank', '_self', '_parent', '_top'])
+              || preg_match('/^[^\W_][\w]+$/i', $target);
     }
 }

--- a/src/Tag/Tag.php
+++ b/src/Tag/Tag.php
@@ -161,6 +161,8 @@ abstract class Tag extends Xbbcode
         $out = '';
         if (isset($parse['scheme'])) {
             $out .= $parse['scheme'] . '://';
+        }elseif('//' == substr($url, 0, 2)){
+            $out .= '//';
         }
         if (isset($parse['user'], $parse['pass'])) {
             $out .= \rawurlencode($parse['user']) . ':' . \rawurlencode($parse['pass']) . '@';

--- a/tests/Tag/ATest.php
+++ b/tests/Tag/ATest.php
@@ -34,4 +34,19 @@ class ATest extends \PHPUnit\Framework\TestCase
         $xbbcode->parse($text);
         $this->assertEquals($result, $xbbcode->getHtml());
     }
+
+    public function testTargetValidate(): void {
+        $variants = [
+              ['[a target=_blank]/[/a]', '<a class="bb" href="/" target="_blank">/</a>'],
+              ['[a target=go_od]/[/a]', '<a class="bb" href="/" target="go_od">/</a>'],
+              ['[a target=_err]/[/a]', '<a class="bb" href="/">/</a>'],
+        ];
+
+        $xbbcode = new Xbbcode();
+        $xbbcode->setAutoLinks(false);
+        foreach ($variants as [$in, $out]) {
+            $xbbcode->parse($in);
+            $this->assertEquals($out, $xbbcode->getHtml());
+        }
+    }
 }


### PR DESCRIPTION
https://html.spec.whatwg.org/#links-created-by-a-and-area-elements
The target attribute, if present, must be a valid browsing context name or keyword.
A valid browsing context name or keyword is any string that is either a valid browsing context name or that is an ASCII case-insensitive match for one of: _blank, _self, _parent, or _top.